### PR TITLE
add one more label

### DIFF
--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -9,18 +9,13 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: read
+  issues: write
 
 jobs:
   sync-labels:
     if: ${{ github.repository_owner == 'AOSSIE-Org' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get PR details
         id: pr-details
         uses: actions/github-script@v7


### PR DESCRIPTION
By estimating size based on the number of lines.
Also, I will first remove all existing size labels, because the size of a PR should depend on the PR’s line changes, not on the manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PRs now automatically receive size labels (XS, S, M, L, XL).
  * Size label assignment moved earlier in the workflow.
  * Contributor-based labeling now runs after size labeling.
  * Minor workflow cleanup and improved logging for label application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->